### PR TITLE
Hide empty joins/leaves

### DIFF
--- a/LxBTSC/template/js/messages.js
+++ b/LxBTSC/template/js/messages.js
@@ -135,15 +135,18 @@ function Ts3ServerStopped(target, time, message) {
 
 function Ts3ClientConnected(target, time, link, name) {
     ++msgid;
+    if (!name) { return; }
     AddStatusMessage(target, StatusTextTemplate(msgid, "TextMessage_ClientConnected", time, '<a href="'+link+'" class="TextMessage_UserLink" oncontextmenu="Ts3LinkClicked(event)">"'+name+'"</a> connected'));
 }
 
 function Ts3ClientDisconnected(target, time, link, name, message) {
     ++msgid;
+    if (!name) { return; }
     AddStatusMessage(target, StatusTextTemplate(msgid, "TextMessage_ClientDisconnected", time, '<a href="'+link+'" class="TextMessage_UserLink" oncontextmenu="Ts3LinkClicked(event)">"'+name+'"</a> disconnected ('+message+')'));
 }
 
 function Ts3ClientTimeout(target, time, link, name) {
     ++msgid;
+    if (!name) { return; }
     AddStatusMessage(target, StatusTextTemplate(msgid, "TextMessage_ClientDropped", time, '<a href="'+link+'" class="TextMessage_UserLink" oncontextmenu="Ts3LinkClicked(event)">"'+name+'"</a> timed out'));
 }


### PR DESCRIPTION
I know this is not a fix but a workaround but the empty join/leave messages make no sense :(